### PR TITLE
fix: close sql rows

### DIFF
--- a/internal/repository/handler_find_client.go
+++ b/internal/repository/handler_find_client.go
@@ -17,6 +17,7 @@ func FindClient(id int) (*entities.Client, error) {
 		slog.Error(err.Error())
 		return nil, errors.New("internal error")
 	}
+	defer item.Close()
 
 	var client entities.Client
 

--- a/internal/repository/handler_list_transaction.go
+++ b/internal/repository/handler_list_transaction.go
@@ -14,6 +14,8 @@ func ListTransaction(id int) ([]entities.Transaction, error) {
 		return nil, errors.New("internal error")
 	}
 
+	defer items.Close()
+
 	var transactions []entities.Transaction
 
 	for items.Next() {


### PR DESCRIPTION
## Qual o motivo da alteração?

Ao realizar a primeira teste de carga na api, tomei vários erros de `pq: sorry, too many clients already` muitos mesmo.
Então buscando sobre esse problema encontrei o seguinte comentário: `I was using db.Query without closing the returned rows object and was repeatedly calling that function` [link](https://stackoverflow.com/questions/53885511/pq-sorry-too-many-clients-already). Vi que erra isso que faltava e  rodei os teste novamente, e melhorou bastante!

Antes:
<img width="1162" alt="rinha_teste_01" src="https://github.com/JPauloMoura/rinha-backend-q1-2024/assets/62079201/5f95e5f3-86f5-4a0a-a25c-0496efff4c42">


Depois:
<img width="1172" alt="rinha_teste_02" src="https://github.com/JPauloMoura/rinha-backend-q1-2024/assets/62079201/a9e6bf0a-7c94-4529-9639-ee1d1324518f">


Ainda não estou usando as duas instancias do servidor, load balance e nem os limites de recursos. Esses serão os próximos passos.
