### PR TITLE
fix: adjusts requirements

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,6 @@ services:
   postgres-rinha:
     image: postgres:16-alpine
     container_name: postgres-rinha
-    command: postgres -c 'max_connections=700'
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: test@localhost.com
@@ -28,7 +27,7 @@ services:
       resources:
         limits:
           cpus: "0.4"
-          memory: "200MB"
+          memory: "140MB"
           
   api-rinha-01: &api
     image: api-rinha
@@ -44,7 +43,7 @@ services:
       resources:
         limits:
           cpus: "0.5"
-          memory: "140MB"
+          memory: "155MB"
 
   api-rinha-02:
     <<: *api
@@ -55,7 +54,7 @@ services:
   nginx:
     image: nginx:latest
     volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx.conf:/etc/nginx/nginx.conf
     depends_on:
       - api-rinha-01
       - api-rinha-02
@@ -65,7 +64,7 @@ services:
       resources:
         limits:
           cpus: "0.2"
-          memory: "70MB"
+          memory: "100MB"
 
 networks:
   default:

--- a/init.sql
+++ b/init.sql
@@ -19,7 +19,6 @@ VALUES
     ('kid mais', 5000 * 100, 0);
 
 CREATE TABLE IF NOT EXISTS transactions (
-    id serial PRIMARY KEY,
     clientId INT,
     valor INT,
     tipo varchar(1),

--- a/internal/entities/transaction.go
+++ b/internal/entities/transaction.go
@@ -6,7 +6,6 @@ import (
 )
 
 type Transaction struct {
-	Id          int       `json:"id"`
 	ClientId    int       `json:"clientId"`
 	Value       int       `json:"valor"`
 	Type        string    `json:"tipo"`

--- a/internal/handler/handler_create_transaction.go
+++ b/internal/handler/handler_create_transaction.go
@@ -36,7 +36,7 @@ func CreateTransaction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err = service.CreateTransaction(id, t)
+	resp, err := service.CreateTransaction(id, t)
 	if err != nil && err.Error() == "client not found" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -54,5 +54,5 @@ func CreateTransaction(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-
+	json.NewEncoder(w).Encode(resp)
 }

--- a/internal/handler/handler_create_transaction.go
+++ b/internal/handler/handler_create_transaction.go
@@ -16,7 +16,7 @@ func CreateTransaction(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.Atoi(chi.URLParam(r, "id"))
 	if err != nil {
 		slog.Debug(err.Error())
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
@@ -24,7 +24,7 @@ func CreateTransaction(w http.ResponseWriter, r *http.Request) {
 	err = json.NewDecoder(r.Body).Decode(&t)
 	if err != nil {
 		slog.Debug(err.Error())
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusUnprocessableEntity)
 		return
 	}
 
@@ -32,7 +32,7 @@ func CreateTransaction(w http.ResponseWriter, r *http.Request) {
 	err = t.Validate()
 	if err != nil {
 		slog.Debug(err.Error())
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusUnprocessableEntity)
 		return
 	}
 

--- a/internal/handler/handler_generate_extract.go
+++ b/internal/handler/handler_generate_extract.go
@@ -14,11 +14,16 @@ func GenerateExtract(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.Atoi(chi.URLParam(r, "id"))
 	if err != nil {
 		slog.Debug(err.Error())
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
 	extract, err := service.GenerateExtract(id)
+	if err != nil && err.Error() == "client not found" {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
 	if err != nil {
 		slog.Debug(err.Error())
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -24,6 +24,9 @@ func ConnectDB() {
 		log.Fatal("failed parse config", err)
 	}
 
+	cfg.MaxConns = 20
+	cfg.MinConns = 10
+
 	conn, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
 		slog.Debug("failed to create connection. check if the database is running or if the connection string is correct",

--- a/internal/repository/handler_list_transaction.go
+++ b/internal/repository/handler_list_transaction.go
@@ -20,7 +20,7 @@ func ListTransaction(id int) ([]entities.Transaction, error) {
 	for items.Next() {
 		var t entities.Transaction
 
-		if err := items.Scan(&t.Id, &t.ClientId, &t.Value, &t.Type, &t.Description, &t.CreatedAt); err != nil {
+		if err := items.Scan(&t.ClientId, &t.Value, &t.Type, &t.Description, &t.CreatedAt); err != nil {
 			slog.Error(err.Error())
 			return nil, errors.New("internal error")
 		}

--- a/internal/repository/handler_list_transaction.go
+++ b/internal/repository/handler_list_transaction.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ListTransaction(id int) ([]entities.Transaction, error) {
-	items, err := DB.Query(context.TODO(), "SELECT * FROM transactions WHERE clientId=$1", id)
+	items, err := DB.Query(context.TODO(), "SELECT * FROM transactions WHERE clientId=$1 ORDER BY realizada_em DESC LIMIT 10", id)
 	if err != nil {
 		slog.Error(err.Error())
 		return nil, errors.New("internal error")

--- a/internal/service/handler_create_transaction.go
+++ b/internal/service/handler_create_transaction.go
@@ -8,19 +8,13 @@ import (
 )
 
 type CreateTransactionResponse struct {
-	Limit int `json:"limite"`
 	Saldo int `json:"saldo"`
+	Limit int `json:"limite"`
 }
 
 func CreateTransaction(clientId int, t entities.Transaction) (*CreateTransactionResponse, error) {
-	// 'c' -> adicionat o valor ao saldo
-	// 'd' -> descontar o valor do saldo
-	// o limite é apenas um valor de consulta para as  validações
-
-	// buscar as informaçõe do client
 	client, err := repository.FindClient(clientId)
 	if err != nil {
-		// slog.Warn(err.Error())
 		return nil, err
 	}
 
@@ -32,19 +26,17 @@ func CreateTransaction(clientId int, t entities.Transaction) (*CreateTransaction
 	}
 
 	if !client.SaldoIsValid() {
-		// slog.Warn("new saldo is invalid")
 		return nil, errors.New("transaction invalid")
 	}
 
 	t.ClientId = client.Id
 	err = repository.CreateTransaction(client, t)
 	if err != nil {
-		// slog.Warn(err.Error())
 		return nil, err
 	}
 
 	return &CreateTransactionResponse{
-		Limit: client.Limit,
 		Saldo: client.Saldo,
+		Limit: client.Limit,
 	}, nil
 }

--- a/internal/service/handler_generate_extract.go
+++ b/internal/service/handler_generate_extract.go
@@ -28,35 +28,13 @@ func NewExtract(c entities.Client, t []entities.Transaction) *Extract {
 	ext := Extract{
 		Saldo: ClientSaldo{
 			Total:       c.Saldo,
-			DataExtrato: time.Now().In(date.LocationBR()).Format(date.DATE_BR_WITH_HOURS),
+			DataExtrato: time.Now().In(date.LocationBR()).String(),
 			Limite:      c.Limit,
 		},
-		UltimasTransacoes: make([]ExtractTransaction, 0),
-	}
-
-	if len(t) == 0 {
-		return &ext
-	}
-
-	for _, v := range t {
-		e := ExtractTransaction{
-			Valor:       v.Value,
-			Tipo:        v.Type,
-			Descricao:   v.Description,
-			RealizadaEm: v.CreatedAt.Format(date.DATE_BR_WITH_HOURS),
-		}
-
-		ext.UltimasTransacoes = append(ext.UltimasTransacoes, e)
+		UltimasTransacoes: t,
 	}
 
 	return &ext
-}
-
-type ExtractTransaction struct {
-	Valor       int    `json:"valor"`
-	Tipo        string `json:"tipo"`
-	Descricao   string `json:"descricao"`
-	RealizadaEm string `json:"realizada_em"`
 }
 
 type ClientSaldo struct {
@@ -66,6 +44,6 @@ type ClientSaldo struct {
 }
 
 type Extract struct {
-	Saldo             ClientSaldo          `json:"saldo"`
-	UltimasTransacoes []ExtractTransaction `json:"ultimas_transacoes"`
+	Saldo             ClientSaldo            `json:"saldo"`
+	UltimasTransacoes []entities.Transaction `json:"ultimas_transacoes"`
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,12 +1,12 @@
 worker_processes auto;  ## Default: 1
 
 events {
-    worker_connections 1300;
+    worker_connections 6000;
 }
 
 http {
-    proxy_read_timeout 45s;
-    proxy_connect_timeout 45s;
+    proxy_read_timeout 300s;
+    proxy_connect_timeout 300s;
     access_log off;
     sendfile   on;
 


### PR DESCRIPTION
## Qual é o motivo dessa alteração?
Não estava conseguindo evoluir nas métricas do teste de carga. Qualquer configuração que eu fazia tinha um número super alto de KO, mesmo usando mais hardware do que o especificado na rinha.

Até que na minha busca por "o que que tó fazendo de errado", encontrei um [video do youtube](https://www.youtube.com/watch?v=YBljoTbdeQ4&lc=UgyLuh52cbiGvgsYTEJ4AaABAg.A-rixAK_0v0A-scxWl2v-C) do [Marco Pegoraro](https://www.youtube.com/@marcoagpegoraro) que ele falava como estava implementando em Vlang, ele comentou que o endpoint de extrato deveria retornar apenas as 10 ultimas transações. 
Putz vacilei feio kkkkk. Eu estava retornando TODAS as transações feitas!
Isso fazia minha aplicação perde chamadas por conta da lentidão e também morrer por falta de memória.
Olha só como tava:
<img width="885" alt="rinha_01" src="https://github.com/JPauloMoura/rinha-backend-q1-2024/assets/62079201/ccc9cee7-8afd-4d64-ab41-f061495a1084">

Observe que a maior quantidade de erros é esse:
```scala
jmesPath(limite).find.exists preparation crashed: Jackson failed to parse into a valid AST: 
c.f.j.d.e.MismatchedInputException: No content to map due to end-of-input at [Source: REDACTED 
(`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1]
``` 
Isso acontecia pq eu não estava devolvendo o json response quando uma transação era criada! Que vacilo kkk

Com isso analisei melhor as regras e funcionalidade solicitadas e fiz os seguintes ajustes:
* Listagem das últimas 10 transações ordenadas pela data de criação para o endpoint de extrato.
* Utilização dos status code 422 para validação dos campos (eu estava usando 400).
* Adição da response correta para criação de transações.
* Remoção do campo de ID como chave primaria auto gerada da tabela de transações.
* Ajustes de nas configurações do postgres e nginx (vou continuar mexendo nisso heheh)

No final melhoramos bastante:
<img width="885" alt="rinha_02" src="https://github.com/JPauloMoura/rinha-backend-q1-2024/assets/62079201/0093fed5-cfbd-4a51-a0af-d56536a67382">

Temos mais de 8k de erros `j.i.IOException: Premature close` mais ainda não consegui saber como resolver.

Continuamos a jornada!